### PR TITLE
Disable WhiteSource Bolt

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,6 +1,6 @@
 {
   "generalSettings": {
-    "shouldScanRepo": true
+    "shouldScanRepo": false
   },
   "checkRunSettings": {
     "vulnerableCheckRunConclusionLevel": "failure"


### PR DESCRIPTION
WhiteSource Bolt does not support Flutter and errors on every build. For this reason, I am disabling it.