### PR TITLE
Delete .whitesource outright

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-{
-  "generalSettings": {
-    "shouldScanRepo": false
-  },
-  "checkRunSettings": {
-    "vulnerableCheckRunConclusionLevel": "failure"
-  }
-}


### PR DESCRIPTION
Changing the option to scan the repo in `.whitesource` to `false` seems to have had no effect. Getting rid of the configuration file should work.